### PR TITLE
Changed nonsensible idle to *REAL* idle

### DIFF
--- a/apps/concurrent/js/prescribed_stories.js
+++ b/apps/concurrent/js/prescribed_stories.js
@@ -28,6 +28,7 @@ SHOOT21 causes not ALIVE1 if ALIVE2 and not JAMMED2 and FACING21
 SHOOT23 causes not ALIVE3 if ALIVE2 and not JAMMED2 and FACING23
 SHOOT31 causes not ALIVE1 if ALIVE3 and not JAMMED3 and FACING31
 SHOOT32 causes not ALIVE2 if ALIVE3 and not JAMMED3 and FACING32
+IDLE causes true
 impossible SHOOT31 at 0
 impossible SHOOT32 at 0
 impossible SHOOT31 at 1
@@ -50,7 +51,7 @@ LOAD3 causes not JAMMED3 if ALIVE3`,
             new Entry("SHOOT12,SHOOT23", 1),
             new Entry("ROTATE13,ROTATE21,SHOOT31", 2),
             new Entry("SHOOT13,SHOOT21,ROTATE32", 3),
-            new Entry("SHOOT32", 4)
+            new Entry("SHOOT32,IDLE", 4)
         ],
         query: new Query(`5`, `Possibly accessible γ at t when Sc`, `ALIVE1 and not ALIVE2 and not ALIVE3`, `5`, ``, `possibly accessible ALIVE1 and not ALIVE2 and not ALIVE3 at 5`)
     },

--- a/apps/concurrent/modules/warsaw_standoff.pl
+++ b/apps/concurrent/modules/warsaw_standoff.pl
@@ -86,15 +86,6 @@ warsaw_standoff_domain(Domain) :-
     list_to_assoc(["causes"-(negate("JAMMED3"), "ALIVE3")], Load3_Causes_List), 
 
 
-    %*************IDLE
-
-    %IDLE1
-    list_to_assoc([], Idle1_Releases_List), 
-
-    %IDLE2
-    list_to_assoc([], Idle2_Releases_List), 
-
-
     %CREATING DOMAIN
     list_to_assoc(["SHOOT12"-Shoot12_Causes_List, "SHOOT13"-Shoot13_Causes_List,
                    "SHOOT21"-Shoot21_Causes_List, "SHOOT23"-Shoot23_Causes_List,
@@ -103,7 +94,6 @@ warsaw_standoff_domain(Domain) :-
                    "ROTATE21"-Rotate21_Causes_List, "ROTATE23"-Rotate23_Causes_List,
                    "ROTATE31"-Rotate31_Causes_List, "ROTATE32"-Rotate32_Causes_List,
                    "LOAD1"-Load1_Releases_List, "LOAD2"-Load2_Releases_List,
-                   "IDLE1"-Idle1_Releases_List, "IDLE2"-Idle2_Releases_List,
                    "LOAD3"-Load3_Causes_List], Domain).
 
 warsaw_standoff_scenario(Sc) :-
@@ -125,7 +115,7 @@ warsaw_standoff_scenario(Sc) :-
                     1-["SHOOT12", "SHOOT23"],
                     2-["ROTATE13", "ROTATE21", "SHOOT31"],
                     3-["SHOOT13", "SHOOT21", "ROTATE32"],
-                    4-["SHOOT32","IDLE1","IDLE2"]], Compound_Actions),
+                    4-["SHOOT32","ROTATE12","ROTATE21"]], Compound_Actions),
     Sc = (Observations, Compound_Actions).
 
 % main_warsaw :-  

--- a/apps/concurrent/modules/warsaw_standoff.pl
+++ b/apps/concurrent/modules/warsaw_standoff.pl
@@ -84,6 +84,7 @@ warsaw_standoff_domain(Domain) :-
 
     %LOAD3
     list_to_assoc(["causes"-(negate("JAMMED3"), "ALIVE3")], Load3_Causes_List), 
+    list_to_assoc(["causes"-(true, true)], Idle_Causes_List), 
 
 
     %CREATING DOMAIN
@@ -94,6 +95,7 @@ warsaw_standoff_domain(Domain) :-
                    "ROTATE21"-Rotate21_Causes_List, "ROTATE23"-Rotate23_Causes_List,
                    "ROTATE31"-Rotate31_Causes_List, "ROTATE32"-Rotate32_Causes_List,
                    "LOAD1"-Load1_Releases_List, "LOAD2"-Load2_Releases_List,
+                   "IDLE"-Idle_Causes_List,
                    "LOAD3"-Load3_Causes_List], Domain).
 
 warsaw_standoff_scenario(Sc) :-
@@ -115,7 +117,7 @@ warsaw_standoff_scenario(Sc) :-
                     1-["SHOOT12", "SHOOT23"],
                     2-["ROTATE13", "ROTATE21", "SHOOT31"],
                     3-["SHOOT13", "SHOOT21", "ROTATE32"],
-                    4-["SHOOT32","ROTATE12","ROTATE21"]], Compound_Actions),
+                    4-["SHOOT32","IDLE"]], Compound_Actions),
     Sc = (Observations, Compound_Actions).
 
 % main_warsaw :-  

--- a/apps/concurrent/test/warsaw_standoff_story.plt
+++ b/apps/concurrent/test/warsaw_standoff_story.plt
@@ -30,10 +30,10 @@ test(possibly_accessible_alive2_at_5) :-
     run_scenario(Scenario, Domain, Query).
 
 
-test(possibly_accessible_alive3_and_jammed1_at_5) :-
+test(possibly_executable_shoot32_idle_at_4) :-
     warsaw_standoff_domain(Domain),
     warsaw_standoff_scenario(Scenario),
-    get_query_from_text(Query, 'possibly accessible ALIVE3 and JAMMED1 at 5'),
-    not(run_scenario(Scenario, Domain, Query)).
+    get_query_from_text(Query, 'possibly executable SHOOT32, IDLE at 4'),
+    run_scenario(Scenario, Domain, Query).
 
 :- end_tests(warsaw_standoff).

--- a/apps/concurrent/test/warsaw_standoff_story.plt
+++ b/apps/concurrent/test/warsaw_standoff_story.plt
@@ -30,6 +30,12 @@ test(possibly_accessible_alive2_at_5) :-
     run_scenario(Scenario, Domain, Query).
 
 
+test(possibly_accessible_alive3_and_jammed1_at_5) :-
+    warsaw_standoff_domain(Domain),
+    warsaw_standoff_scenario(Scenario),
+    get_query_from_text(Query, 'possibly accessible ALIVE3 and JAMMED1 at 5'),
+    not(run_scenario(Scenario, Domain, Query)).
+
 test(possibly_executable_shoot32_idle_at_4) :-
     warsaw_standoff_domain(Domain),
     warsaw_standoff_scenario(Scenario),


### PR DESCRIPTION
I have added IDLE so that the scenario is executable but there was a problem with generating an idle action (skip?). So I suggest to rotate the gangsters as a slightly more sensible than nonsensible idle action. Our tests pass