### PR TITLE
Simplified Concurrent.pl redundant potentially_executable calling

### DIFF
--- a/apps/concurrent/concurrent.pl
+++ b/apps/concurrent/concurrent.pl
@@ -70,7 +70,7 @@ exists_state_at_query_time_invalidating_condition(Query_Condition, Query_Time, T
 
 
 exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Time, Query_Time, Fluent_Assignments, _, _, Action_Domain) :-
-    not(compound_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments, Query_Action)).
+    not(compound_executable(Query_Time, Action_Domain, Fluent_Assignments, Query_Action)).
 
 exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Time, Time, Fluent_Assignments, Observations, Actions, Action_Domain) :-
     Time < Query_Time,
@@ -80,7 +80,7 @@ exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Tim
 
 
 exists_state_at_query_time_executing_action(Query_Action, Query_Time, Query_Time, Fluent_Assignments, _, _, Action_Domain) :-
-    compound_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments, Query_Action).
+    compound_executable(Query_Time, Action_Domain, Fluent_Assignments, Query_Action).
 
 exists_state_at_query_time_executing_action(Query_Action, Query_Time, Time, Fluent_Assignments, Observations, Actions, Action_Domain) :-
     Time < Query_Time,

--- a/apps/concurrent/concurrent.pl
+++ b/apps/concurrent/concurrent.pl
@@ -70,9 +70,7 @@ exists_state_at_query_time_invalidating_condition(Query_Condition, Query_Time, T
 
 
 exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Time, Query_Time, Fluent_Assignments, _, _, Action_Domain) :-
-    (maplist(potentially_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments), Query_Action)
-    ->  not(compound_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments, Query_Action))
-    ;   true).
+    not(compound_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments, Query_Action)).
 
 exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Time, Time, Fluent_Assignments, Observations, Actions, Action_Domain) :-
     Time < Query_Time,
@@ -82,7 +80,6 @@ exists_state_at_query_time_that_could_not_execute_action(Query_Action, Query_Tim
 
 
 exists_state_at_query_time_executing_action(Query_Action, Query_Time, Query_Time, Fluent_Assignments, _, _, Action_Domain) :-
-    maplist(potentially_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments), Query_Action),
     compound_executable_atomic(Query_Time, Action_Domain, Fluent_Assignments, Query_Action).
 
 exists_state_at_query_time_executing_action(Query_Action, Query_Time, Time, Fluent_Assignments, Observations, Actions, Action_Domain) :-

--- a/apps/concurrent/modules/compound_executable.pl
+++ b/apps/concurrent/modules/compound_executable.pl
@@ -1,6 +1,6 @@
 :- module(compound_executable,
     [
-        compound_executable_atomic/4
+        compound_executable/4
 	]).
 :- use_module(potentially_executable).
 :- use_module(logic_formula_satisfiability).
@@ -38,7 +38,7 @@ conjunct(Statement, [], Statement).
 conjunct(Statement, Acc1, and(Statement, Acc1)).
 
 
-compound_executable_atomic(Time, Action_Domain, Fluent_Assignments, Compound_Action) :-
+compound_executable(Time, Action_Domain, Fluent_Assignments, Compound_Action) :-
     dif(Compound_Action, []),
     maplist(potentially_executable_atomic(Time, Action_Domain, Fluent_Assignments), Compound_Action),
     findall(Causes_Condition,

--- a/apps/concurrent/modules/mns.pl
+++ b/apps/concurrent/modules/mns.pl
@@ -13,11 +13,11 @@ mns(PotentiallyExecutablesList, Time, Action_Domain, Fluent_Assignments, Some_Va
 
 % check_whether_compound_is_valid(IncludedActions, ConsideredActions, Time, Action_Domain, Fluent_Assignments, CompoundAction) :-
 %     append(IncludedActions, ConsideredActions, CompoundAction),
-%     compound_executable_atomic(Time, Action_Domain, Fluent_Assignments, CompoundAction).
+%     compound_executable(Time, Action_Domain, Fluent_Assignments, CompoundAction).
 
 check_whether_compound_is_valid(IncludedActions, ConsideredActions, Time, Action_Domain, Fluent_Assignments, Some_Valid_MNS) :-
     append(IncludedActions, ConsideredActions, CompoundAction),
-    (compound_executable_atomic(Time, Action_Domain, Fluent_Assignments, CompoundAction) ->
+    (compound_executable(Time, Action_Domain, Fluent_Assignments, CompoundAction) ->
         Some_Valid_MNS = CompoundAction
     ;
         check_without_first_considering(IncludedActions, ConsideredActions, Time, Action_Domain, Fluent_Assignments, Some_Valid_MNS)

--- a/apps/concurrent/modules/next_state.pl
+++ b/apps/concurrent/modules/next_state.pl
@@ -8,7 +8,7 @@
 :- use_module(potentially_executable).
 :- use_module(logic_formula_satisfiability).
 
-%compound_executable_atomic(Compound_Action, Time, Action_Domain, Fluent_Assignments)
+%compound_executable(Compound_Action, Time, Action_Domain, Fluent_Assignments)
 
 get_nonempty_action_decomposition(Compound_Action, Time, Action_Domain, Fluent_Assignments, Action_Decomposition) :-
     mns(Compound_Action, Time, Action_Domain, Fluent_Assignments, Action_Decomposition),


### PR DESCRIPTION
Predicate potentially executable is needlessly called in numerous places because it is already being called by compound_executable. Additionally renamed predicate to a more aesthetic name