### PR TITLE
quote fixes, provided input should be a string not an atom

### DIFF
--- a/apps/concurrent/test/tas_true_false.plt
+++ b/apps/concurrent/test/tas_true_false.plt
@@ -5,14 +5,14 @@
 :- use_module("../concurrent.pl").
 
 get_domain_scenario(Domain, Scenario) :-
-    parse_domain(`THINKABOUTSUNDAY causes not MOVING
+    parse_domain("THINKABOUTSUNDAY causes not MOVING
                     ALARM causes MOVING if ALIVE
                     SHOOT causes not ALIVE and not MOVING if not MOVING
-					DESTROY causes false`, Domain),
-    parse_acs('SHOOT,THINKABOUTSUNDAY,DESTROY|0
+					DESTROY causes false", Domain),
+    parse_acs("SHOOT,THINKABOUTSUNDAY,DESTROY|0
                     SHOOT,THINKABOUTSUNDAY,ALARM,DESTROY|1
-                    SHOOT,DESTROY|2', Acs),
-    parse_obs('ALIVE and MOVING|0', Obs),
+                    SHOOT,DESTROY|2", Acs),
+    parse_obs("ALIVE and MOVING|0", Obs),
     Scenario = (Obs, Acs).
 
 test('possibly executable') :-

--- a/apps/concurrent/test/tas_with_wait.plt
+++ b/apps/concurrent/test/tas_with_wait.plt
@@ -5,15 +5,15 @@
 :- use_module("../concurrent.pl").
 
 get_domain_scenario(Domain, Scenario) :-
-    parse_domain(`WAIT causes wait
+    parse_domain("WAIT causes wait
                     THINKABOUTSUNDAY causes not MOVING
                     ALARM causes MOVING if ALIVE
-                    SHOOT causes not ALIVE and not MOVING if not MOVING`, Domain),
-    parse_acs('WAIT|0
+                    SHOOT causes not ALIVE and not MOVING if not MOVING", Domain),
+    parse_acs("WAIT|0
 					SHOOT,THINKABOUTSUNDAY|1
                     SHOOT,THINKABOUTSUNDAY,ALARM|2
-                    SHOOT|3', Acs),
-    parse_obs('ALIVE and MOVING|0', Obs),
+                    SHOOT|3", Acs),
+    parse_obs("ALIVE and MOVING|0", Obs),
     Scenario = (Obs, Acs).
 
 test('possibly executable SHOOT at 3') :-


### PR DESCRIPTION
Test were failing because someone used an atom as input instead of a string